### PR TITLE
Release: Kubernetes 1.34.2 on Fedora 43

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -152,7 +152,7 @@ STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT [ "/sbin/init" ]
 
 # Labels for metadata
-LABEL io.kinc.version="v1.34.1-rootless"
+LABEL io.kinc.version="v1.34.2-rootless"
 LABEL io.kinc.runtime="crio"
 LABEL io.kinc.init="baked-in"
 LABEL io.kinc.rootless="true"

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -1,6 +1,6 @@
 # kinc Consolidated Kubernetes Node
 # Single-stage Dockerfile that combines base Fedora + CRI-O + kinc components
-FROM fedora:42
+FROM fedora:43
 
 # Set container metadata for systemd
 ENV container=docker
@@ -24,12 +24,12 @@ RUN echo "Installing Packages (cache bust: $CACHE_BUST)..." \
       libseccomp pigz fuse-overlayfs \
       nfs-utils iscsi-initiator-utils \
       bash ca-certificates curl jq yq procps-ng which hostname \
-      cri-o1.33 crun \
+      cri-o1.34 crun \
       containernetworking-plugins \
       container-selinux \
-      kubernetes1.33 \
-      kubernetes1.33-kubeadm \
-      cri-tools1.33 \
+      kubernetes1.34 \
+      kubernetes1.34-kubeadm \
+      cri-tools1.34 \
     && dnf clean all
 
 # Configure systemd (separate layer for better caching)
@@ -152,7 +152,7 @@ STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT [ "/sbin/init" ]
 
 # Labels for metadata
-LABEL io.kinc.version="v1.33.5-rootless"
+LABEL io.kinc.version="v1.34.1-rootless"
 LABEL io.kinc.runtime="crio"
 LABEL io.kinc.init="baked-in"
 LABEL io.kinc.rootless="true"

--- a/build/kinc/etc/kinc/kubeadm.conf
+++ b/build/kinc/etc/kinc/kubeadm.conf
@@ -16,7 +16,7 @@ controllerManager:
   - name: enable-hostpath-provisioner
     value: "true"
 kind: ClusterConfiguration
-kubernetesVersion: v1.33.5
+kubernetesVersion: v1.34.1
 networking:
   podSubnet: 10.244.0.0/16
   serviceSubnet: 10.96.0.0/16

--- a/build/kinc/etc/kinc/kubeadm.conf
+++ b/build/kinc/etc/kinc/kubeadm.conf
@@ -16,7 +16,7 @@ controllerManager:
   - name: enable-hostpath-provisioner
     value: "true"
 kind: ClusterConfiguration
-kubernetesVersion: v1.34.1
+kubernetesVersion: v1.34.2
 networking:
   podSubnet: 10.244.0.0/16
   serviceSubnet: 10.96.0.0/16

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -103,7 +103,7 @@ echo
 echo "🚀 Next steps:"
 echo "  1. Deploy default: ./tools/deploy.sh"
 echo "  2. Deploy custom:  CLUSTER_NAME=stage ./tools/deploy.sh"
-echo "  3. Test:           CLUSTER_NAME=default ./tools/test.sh"
+echo "  3. Validate:       ./tools/run-validation.sh"
 echo "  4. Clean:          CLUSTER_NAME=default ./tools/cleanup.sh"
 echo
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -6,7 +6,8 @@ echo "============================="
 
 # Single image for all clusters (no cluster name in tag)
 # Build once, deploy many times with different configs
-IMAGE_NAME="localhost/kinc/node:v1.33.5"
+# Note: Update this when upgrading Kubernetes version
+IMAGE_NAME="localhost/kinc/node:v1.34.1"
 
 # Cache busting for package updates (increment when packages need updating)
 CACHE_BUST="${CACHE_BUST:-1}"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -97,7 +97,7 @@ echo "✅ Validation complete - Baked-in configuration active!"
 # Show image size
 echo
 echo "📊 Image information:"
-podman images | grep "kinc/node.*v1.33.5"
+podman images | grep "kinc/node.*v1.34"
 
 echo
 echo "🚀 Next steps:"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -7,7 +7,7 @@ echo "============================="
 # Single image for all clusters (no cluster name in tag)
 # Build once, deploy many times with different configs
 # Note: Update this when upgrading Kubernetes version
-IMAGE_NAME="localhost/kinc/node:v1.34.1"
+IMAGE_NAME="localhost/kinc/node:v1.34.2"
 
 # Cache busting for package updates (increment when packages need updating)
 CACHE_BUST="${CACHE_BUST:-1}"

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -14,7 +14,7 @@ FORCE_PORT="${FORCE_PORT:-}"  # Allow manual port override
 # Image configuration - Single image for all clusters
 # All clusters use the same image with different mounted configs
 # Allow KINC_IMAGE env var to override default
-IMAGE_NAME="${KINC_IMAGE:-localhost/kinc/node:v1.33.5}"
+IMAGE_NAME="${KINC_IMAGE:-localhost/kinc/node:v1.34.1}"
 
 echo "📁 Working directory: $SCRIPT_DIR"
 echo "🏷️  Cluster name: $CLUSTER_NAME"

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -14,7 +14,7 @@ FORCE_PORT="${FORCE_PORT:-}"  # Allow manual port override
 # Image configuration - Single image for all clusters
 # All clusters use the same image with different mounted configs
 # Allow KINC_IMAGE env var to override default
-IMAGE_NAME="${KINC_IMAGE:-localhost/kinc/node:v1.34.1}"
+IMAGE_NAME="${KINC_IMAGE:-localhost/kinc/node:v1.34.2}"
 
 echo "📁 Working directory: $SCRIPT_DIR"
 echo "🏷️  Cluster name: $CLUSTER_NAME"

--- a/tools/run-validation.sh
+++ b/tools/run-validation.sh
@@ -16,7 +16,7 @@ echo "╚═══════════════════════�
 echo ""
 
 # Test configuration
-KINC_IMAGE="${KINC_IMAGE:-localhost/kinc/node:v1.33.5}"
+KINC_IMAGE="${KINC_IMAGE:-localhost/kinc/node:v1.34.1}"
 echo "Using image: $KINC_IMAGE"
 echo ""
 

--- a/tools/run-validation.sh
+++ b/tools/run-validation.sh
@@ -16,7 +16,7 @@ echo "╚═══════════════════════�
 echo ""
 
 # Test configuration
-KINC_IMAGE="${KINC_IMAGE:-localhost/kinc/node:v1.34.1}"
+KINC_IMAGE="${KINC_IMAGE:-localhost/kinc/node:v1.34.2}"
 echo "Using image: $KINC_IMAGE"
 echo ""
 

--- a/tools/run-validation.sh
+++ b/tools/run-validation.sh
@@ -28,30 +28,55 @@ echo "Prerequisites: System Configuration Check"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
-# Check IP forwarding
-if [ "$(cat /proc/sys/net/ipv4/ip_forward)" != "1" ]; then
-  echo "❌ IP forwarding disabled - required for Kubernetes networking"
+# Check 1: IP Forwarding (REQUIRED)
+ip_forward=$(cat /proc/sys/net/ipv4/ip_forward)
+if [ "$ip_forward" != "1" ]; then
+  echo "❌ IP forwarding DISABLED"
+  echo "   Required for Kubernetes pod networking!"
+  echo "   Enable with: sudo sysctl -w net.ipv4.ip_forward=1"
+  echo "   To persist:  echo 'net.ipv4.ip_forward=1' | sudo tee -a /etc/sysctl.d/99-kinc.conf"
   exit 1
 fi
-echo "✅ IP forwarding: enabled"
+echo "✅ IP forwarding enabled"
 
-# Check inotify limits
+# Check 2: Inotify limits (REQUIRED for multi-cluster)
 max_watches=$(cat /proc/sys/fs/inotify/max_user_watches)
 max_instances=$(cat /proc/sys/fs/inotify/max_user_instances)
-if [ "$max_watches" -lt 524288 ] || [ "$max_instances" -lt 512 ]; then
-  echo "⚠️  Inotify limits: watches=$max_watches, instances=$max_instances (recommend: 524288, 512)"
+if [ "$max_watches" -lt 524288 ] || [ "$max_instances" -lt 2048 ]; then
+  echo "❌ Inotify limits below recommended"
+  echo "   Current: watches=$max_watches, instances=$max_instances"
+  echo "   Recommended: watches=524288, instances=2048"
+  echo "   Required for validation test (7 clusters)"
+  echo "   To fix: sudo sysctl -w fs.inotify.max_user_watches=524288"
+  echo "           sudo sysctl -w fs.inotify.max_user_instances=2048"
+  echo "   Set KINC_SKIP_SYSCTL_CHECKS=true to bypass (not recommended)"
+  [ "${KINC_SKIP_SYSCTL_CHECKS:-false}" != "true" ] && exit 1
+fi
+echo "✅ Inotify limits sufficient for 5+ clusters"
+
+# Check 3: Kernel keyring limits (RECOMMENDED)
+maxkeys=$(cat /proc/sys/kernel/keys/maxkeys 2>/dev/null || echo "1000")
+maxbytes=$(cat /proc/sys/kernel/keys/maxbytes 2>/dev/null || echo "25000")
+if [ "$maxkeys" -lt 1000 ] || [ "$maxbytes" -lt 25000 ]; then
+  echo "⚠️  Kernel keyring limits below recommended"
+  echo "   Current: maxkeys=$maxkeys, maxbytes=$maxbytes"
+  echo "   Recommended: maxkeys=1000, maxbytes=25000"
+  echo "   To fix: sudo sysctl -w kernel.keys.maxkeys=1000"
+  echo "           sudo sysctl -w kernel.keys.maxbytes=25000"
 else
-  echo "✅ Inotify limits: sufficient for 5+ clusters"
+  echo "✅ Kernel keyring limits sufficient"
 fi
 
-# Check failed services
+# Check 4: Failed services (WARNING only)
 failed=$(systemctl --user list-units --state=failed --no-pager --no-legend 2>/dev/null | wc -l)
 if [ $failed -gt 0 ]; then
   echo "⚠️  Found $failed failed user service(s) - review before testing"
+  echo "   Check with: systemctl --user list-units --state=failed"
 else
   echo "✅ System health: no failed services"
 fi
 
+echo ""
 echo "✅ Prerequisites check complete"
 echo ""
 


### PR DESCRIPTION
- Containerfile: Upgrade to Fedora 43 base image
- Containerfile: Upgrade to Kubernetes 1.34.2 packages (kubernetes1.34)
- Containerfile: Update version label to v1.34.2-rootless
- kubeadm.conf: Update kubernetesVersion to v1.34.2
- tools/*.sh: Update default image tags to v1.34.2

Validated:
- 7 cluster deployment test passed (all running v1.34.2 components)
- Multi-service architecture verified
- All system pods running healthy
- Kubernetes 1.34.2 packages confirmed via rpm
- Component images confirmed: kube-apiserver, controller-manager, scheduler, proxy all v1.34.2